### PR TITLE
Fix region range in relative_expression_similarity_across_genes

### DIFF
--- a/txsim/local/_metrics.py
+++ b/txsim/local/_metrics.py
@@ -199,9 +199,9 @@ def _get_relative_expression_similarity_across_genes_grid(
 
     # only consider cells within the specified region
     adata_sp_region_range = adata_sp[(adata_sp.obs[cells_y_col] >= region_range[0][0]) &
-                                     (adata_sp.obs[cells_y_col] < region_range[0][1]) &
+                                     (adata_sp.obs[cells_y_col] <= region_range[0][1]) &
                                      (adata_sp.obs[cells_x_col] >= region_range[1][0]) &
-                                     (adata_sp.obs[cells_x_col] < region_range[1][1])]
+                                     (adata_sp.obs[cells_x_col] <= region_range[1][1])]
 
     # add "bin" label columns to adata_sp
     adata_sp_region_range.obs["bin_y"] = pd.cut(adata_sp_region_range.obs[cells_y_col], bins=bins[0], labels=False)


### PR DESCRIPTION

### Changes proposed in this pull request:
- Include upper `region_range` bound in the spatial adata used for calculating the `relative_expression_similarity_across_genes` metric
- For real data, this shouldn't really make a difference, but for our simulation, this leads to an entire grid row and column being dropped