### PR TITLE
Fixed binning in local relative expression similarity methods

### DIFF
--- a/txsim/local/_analysis_wrappers.py
+++ b/txsim/local/_analysis_wrappers.py
@@ -8,7 +8,7 @@ from ._cells_based import _get_celltype_ratio_grid, _get_spot_uniformity_within_
 from ._spots_based import _get_spot_density_grid
 from ._metrics import _get_knn_mixing_grid, _get_celltype_proportions_grid
 from ._metrics import _get_relative_expression_similarity_across_genes_grid
-from ._metrics import _get_relative_expression_between_celltypes_grid
+from ._metrics import _get_relative_expression_similarity_across_celltypes_grid
 from ._self_consistency_metrics import _get_ARI_between_cell_assignments_grid
 from ._self_consistency_metrics import _get_spots_based_annotation_similarity_grid
 
@@ -467,7 +467,7 @@ def metrics(
             contribution
         )
     if "relative_expression_similarity_across_celltypes" in metrics:
-        out_dict["relative_expression_similarity_across_celltypes"] = _get_relative_expression_between_celltypes_grid(
+        out_dict["relative_expression_similarity_across_celltypes"] = _get_relative_expression_similarity_across_celltypes_grid(
             adata_sp, adata_sc, region_range, bins, obs_key, layer, cells_x_col, cells_y_col, normalization, 
             contribution
         )

--- a/txsim/local/_metrics.py
+++ b/txsim/local/_metrics.py
@@ -329,7 +329,8 @@ def _get_relative_expression_similarity_across_genes_grid(
 
     return overall_metric_matrix
 
-def _get_relative_expression_between_celltypes_grid(
+
+def _get_relative_expression_similarity_across_celltypes_grid(
     adata_sp: ad.AnnData,
     adata_sc: ad.AnnData,
     region_range: Tuple[Tuple[float, float], Tuple[float, float]],
@@ -393,24 +394,19 @@ def _get_relative_expression_between_celltypes_grid(
         if issparse(a.X):
             a.layers[layer] = a.layers[layer].toarray()
 
+    # get bin ids
+    adata_sp.obs = _get_bin_ids(adata_sp.obs, region_range, bins, cells_x_col, cells_y_col)
+
     # only consider cells within the specified region
-    adata_sp_region_range = adata_sp[(adata_sp.obs[cells_y_col] >= region_range[0][0]) &
-                        (adata_sp.obs[cells_y_col] <= region_range[0][1]) &
-                        (adata_sp.obs[cells_x_col] >= region_range[1][0]) &
-                        (adata_sp.obs[cells_x_col] <= region_range[1][1])]
+    adata_sp_region_range = adata_sp[(adata_sp.obs["y_bin"] != -1) & (adata_sp.obs["x_bin"] != -1)]
 
-    # add "bin" label columns to adata_sp
-    adata_sp_region_range.obs["bin_y"] = pd.cut(adata_sp_region_range.obs[cells_y_col], bins=bins[0], labels=False)
-    adata_sp_region_range.obs["bin_x"] = pd.cut(adata_sp_region_range.obs[cells_x_col], bins=bins[1], labels=False)
-
-    # create empty matrices to store the overall, per-celltype and per-gene metrics
+    # create an empty matrix to store the computed metric for each grid field
     overall_metric_matrix = np.zeros((bins[0], bins[1]))
 
-
-    for y_bin in adata_sp_region_range.obs["bin_y"].unique():
-        for x_bin in adata_sp_region_range.obs["bin_x"].unique():
+    for y_bin in adata_sp_region_range.obs["y_bin"].unique():
+        for x_bin in adata_sp_region_range.obs["x_bin"].unique():
             # subset the spatial data to only include cells in the current grid field
-            adata_sp_local = adata_sp_region_range[(adata_sp_region_range.obs["bin_y"] == y_bin) & (adata_sp_region_range.obs["bin_x"] == x_bin)]
+            adata_sp_local = adata_sp_region_range[(adata_sp_region_range.obs["y_bin"] == y_bin) & (adata_sp_region_range.obs["x_bin"] == x_bin)]
 
             # find the unique celltypes in the grid field, that are both in the adata_sc and in the adata_sp
             unique_celltypes = adata_sc.obs.loc[adata_sc.obs[obs_key].isin(adata_sp_local.obs[obs_key]),obs_key].unique()
@@ -519,8 +515,8 @@ def _get_relative_expression_between_celltypes_grid(
 
         nr_grid_fields = np.sum(~np.isnan(overall_metric_matrix))
         metric_contribution_matrix = np.zeros((bins[0], bins[1]))
-        for y_bin in adata_sp_region_range.obs["bin_y"].unique():
-            for x_bin in adata_sp_region_range.obs["bin_x"].unique():
+        for y_bin in adata_sp_region_range.obs["y_bin"].unique():
+            for x_bin in adata_sp_region_range.obs["x_bin"].unique():
                 # calculate the difference in the local metric matrix explained by the grid field
                 diff_explained_by_grid_field = (nr_grid_fields * (1 - overall_metric_matrix[y_bin, x_bin])
                                                 / (nr_grid_fields - np.nansum(overall_metric_matrix)))


### PR DESCRIPTION

### Changes proposed in this pull request:
- Use `_get_bin_ids` to bin the cells in both relative expression similarity methods
- Renamed `_get_relative_expression_between_celltypes_grid` method to `_get_relative_expression_similarity_across_celltypes_grid` to match the metric naming convention

