### PR TITLE
Fixes in relative expression similarity across celltypes

### DIFF
--- a/txsim/local/_metrics.py
+++ b/txsim/local/_metrics.py
@@ -482,10 +482,6 @@ def _get_relative_expression_similarity_across_celltypes_grid(
             norm_factor_sc = (1/(mean_celltype_sc.T.shape[1]**2)) * abs_diff_sum_sc
             norm_factor_sp = (1/(mean_celltype_sc.T.shape[1]**2)) * abs_diff_sum_sp
 
-            epsilon = 1e-10
-            norm_factor_sc += epsilon
-            norm_factor_sp += epsilon
-
             # perform normalization
             # exclude the ones with norm_factor_sc, norm_factor_sp with zero
             pairwise_distances_sc[:, :, norm_factor_sc != 0] = np.divide(pairwise_distances_sc[:, :, norm_factor_sc != 0],
@@ -494,15 +490,15 @@ def _get_relative_expression_similarity_across_celltypes_grid(
             # distances by the global or local normalization factor
             pairwise_distances_sp_local[:, :, norm_factor_sp != 0] = np.divide(pairwise_distances_sp_local[:, :, norm_factor_sp != 0],
                                                                          norm_factor_sp[norm_factor_sp != 0])
-            norm_pairwise_distances_sc = np.divide(pairwise_distances_sc, norm_factor_sc)
-            norm_pairwise_distances_sp = np.divide(pairwise_distances_sp_local, norm_factor_sp)
+            norm_pairwise_distances_sc = pairwise_distances_sc
+            norm_pairwise_distances_sp_local = pairwise_distances_sp_local
 
-            ##### CALCULATE OVERALL SCORE,PER-GENE SCORES, PER-CELLTYPE SCORES
+            ##### CALCULATE OVERALL SCORE MATRIX
             # First, sum over the differences between modalities in relative pairwise gene expression distances
             # The overall metric is then bounded at a maximum of 1, representing perfect similarity of relative gene expression between modalities.
             ## Furthermore, the metric is constructed such that, when its value is 0, this represents perfect dissimilarity of
             ## relative gene expression between modalities.
-            overall_score = np.sum(np.absolute(norm_pairwise_distances_sp - norm_pairwise_distances_sc), axis=None)
+            overall_score = np.sum(np.absolute(norm_pairwise_distances_sp_local - norm_pairwise_distances_sc), axis=None)
             overall_metric = 1 - (overall_score / (2 * np.sum(np.absolute(norm_pairwise_distances_sc), axis=None)))
             overall_metric_matrix[y_bin, x_bin] = overall_metric
 

--- a/txsim/metrics/_relative_pairwise_celltype_expression.py
+++ b/txsim/metrics/_relative_pairwise_celltype_expression.py
@@ -47,8 +47,8 @@ def relative_pairwise_celltype_expression(adata_sp: AnnData, adata_sc: AnnData, 
             
     # find the unique celltypes in adata_sc that are also in adata_sp
     unique_celltypes=adata_sc.obs.loc[adata_sc.obs[key].isin(adata_sp.obs[key]),key].unique()
-    
-    
+
+
     
     #### FIND MEAN GENE EXPRESSION PER CELL TYPE FOR EACH MODALITY
     # get the adata_sc cell x gene matrix as a pandas dataframe (w gene names as column names)
@@ -96,10 +96,6 @@ def relative_pairwise_celltype_expression(adata_sp: AnnData, adata_sc: AnnData, 
     
     
     #perform normalization
-    norm_pairwise_distances_sc = np.divide(pairwise_distances_sc, norm_factor_sc)
-    norm_pairwise_distances_sp = np.divide(pairwise_distances_sp, norm_factor_sp)
-    
-    
     pairwise_distances_sc[:,:,norm_factor_sc!=0] = np.divide(pairwise_distances_sc[:,:,norm_factor_sc!=0], 
                                                              norm_factor_sc[norm_factor_sc!=0])
     # exclude the ones with norm_factor_sc, norm_factor_sp with zero


### PR DESCRIPTION

### Changes proposed in this pull request:
- Create copies of AnnDatas in the global metric version (`_relative_pairwise_celltype_expression`). Before, calling the function threw an error, as working with views of the AnnData is not sufficient in this case.
- In the local metric version, data were erroneously normalized twice (i.e. divided by the normalization factor twice), leading to strongly negative metric values. I removed the second normalization, so that the procedure now aligns with the global and the across-genes metric versions. Of note, when using global normalization, negative metric values can still occur when spatial and scRNA-seq data deviate strongly, but the negative values are less extreme than before.
- As a result from the previous adjustment, we can now also remove adding the pseudo-count epsilon to the normalization factor, as the initial normalization already deals with zero values itself.
- Removed unused variable assignment for `norm_pairwise_distances_sc` and `norm_pairwise_distances_sp` from `_relative_pairwise_celltype_expression` (global metric version)

