### PR TITLE
Fix normalization for gene set size in relative expression similarity across genes

### DIFF
--- a/txsim/local/_metrics.py
+++ b/txsim/local/_metrics.py
@@ -285,8 +285,8 @@ def _get_relative_expression_similarity_across_genes_grid(
             abs_diff_sum_sp = np.sum(abs_diff_sp, axis=(0, 1))
 
             # calculate normalization factor
-            norm_factor_sc = mean_celltype_sc.shape[1] ** 2 * abs_diff_sum_sc
-            norm_factor_sp = mean_celltype_sc.shape[1] ** 2 * abs_diff_sum_sp
+            norm_factor_sc = (1/(mean_celltype_sc.shape[1] ** 2)) * abs_diff_sum_sc
+            norm_factor_sp = (1/(mean_celltype_sc.shape[1] ** 2)) * abs_diff_sum_sp
 
             # perform normalization
             # exclude the ones with norm_factor_sc, norm_factor_sp with zero

--- a/txsim/metrics/_relative_pairwise_gene_expression.py
+++ b/txsim/metrics/_relative_pairwise_gene_expression.py
@@ -94,8 +94,8 @@ def relative_pairwise_gene_expression(adata_sp: AnnData, adata_sc: AnnData, key:
     abs_diff_sum_sp = np.sum(abs_diff_sp, axis=(0,1))
     
     # calculate normalization factor
-    norm_factor_sc = mean_celltype_sc.shape[1]**2 * abs_diff_sum_sc
-    norm_factor_sp = mean_celltype_sc.shape[1]**2 * abs_diff_sum_sp
+    norm_factor_sc = (1/(mean_celltype_sc.shape[1]**2)) * abs_diff_sum_sc
+    norm_factor_sp = (1/(mean_celltype_sc.shape[1]**2)) * abs_diff_sum_sp
     
     #perform normalization
     # exclude the ones with norm_factor_sc, norm_factor_sp with zero


### PR DESCRIPTION

### Changes proposed in this pull request:
As discussed, the normalization for the gene set size in `relative_pairwise_gene_expression` differs from the mathematical description. I now noticed that in `relative_pairwise_celltype_expression`, the normalization is correctly implemented (with the number of genes or, in this case, cell types in the numerator).

Hence, I suggest adjusting the code for the across-genes version (both global and local) accordingly. When tested on simulated data, this change did not result in big differences in metric values.

